### PR TITLE
point source code to github exploit code in 8.md

### DIFF
--- a/issues/72/8.md
+++ b/issues/72/8.md
@@ -2324,10 +2324,7 @@ gives you some insights on vulnerability exploitation.
 
 --[ 11 - Source code
 
+Please find the exploit source code at
+https://github.com/ptef/CVE-2020-9273/blob/main/exploit_proftpd.c
+
 </PRE>
-```text
-begin 664 proftpd_1.3.7rc2_exploit.tar.gz
-M'XL(`-7*,5X``^P\:W?:2++YS*_HL:_'R`-8XF$GSB1[,,B)3K#Q()S'S.0H
-M`C6@C9!8M7#P[-W[VV]5M]X(C#-)[MW9Z$PLH:Y75U5753\T_L=%E<Z7U<GR
-[..]
-```


### PR DESCRIPTION
the source code, instead of uuencode/uudecode thing I pointed to the github repo, the file would be huge if pasted the encoded code there