### PR TITLE
chore: misc fixes

### DIFF
--- a/issues/49/14.md
+++ b/issues/49/14.md
@@ -827,7 +827,7 @@ void main() {
 <PRE>
 
 </PRE>
-```shell
+```console
 [aleph1]$ gcc -o testsc testsc.c
 [aleph1]$ ./testsc
 $ exit
@@ -905,7 +905,7 @@ void main() {
 <PRE>
 
 </PRE>
-```shell
+```console
 [aleph1]$ gcc -o testsc2 testsc2.c
 [aleph1]$ ./testsc2
 $ exit
@@ -951,7 +951,7 @@ void main() {
 <PRE>
 
 </PRE>
-```shell
+```console
 [aleph1]$ gcc -o exploit1 exploit1.c
 [aleph1]$ ./exploit1
 $ exit
@@ -990,7 +990,7 @@ void main() {
 <PRE>
 
 </PRE>
-```shell
+```console
 [aleph1]$ ./sp
 0x8000470
 [aleph1]$
@@ -1071,7 +1071,7 @@ void main(int argc, char *argv[]) {
    Now we can try to guess what the buffer and offset should be:
 
 </PRE>
-```shell
+```console
 [aleph1]$ ./exploit2 500
 Using address: 0xbffffdb4
 [aleph1]$ ./vulnerable $EGG
@@ -1195,7 +1195,7 @@ buffer we are trying to overflow is 512 bytes long, so we'll use 612.  Let's
 try to overflow our test program with our new exploit:
 
 </PRE>
-```shell
+```console
 [aleph1]$ ./exploit3 612
 Using address: 0xbffffdb4
 [aleph1]$ ./vulnerable $EGG
@@ -1211,7 +1211,7 @@ be running an X server and allow connections to it from the localhost.  Set
 your DISPLAY variable accordingly.
 
 </PRE>
-```shell
+```console
 [aleph1]$ export DISPLAY=:0.0
 [aleph1]$ ./exploit3 1124
 Using address: 0xbffffdb4
@@ -1242,7 +1242,7 @@ Warning: Color name "^1FF
 ^C
 [aleph1]$ exit
 ```
-```shell
+```console
 [aleph1]$ ./exploit3 2148 100
 Using address: 0xbffffd48
 [aleph1]$ /usr/X11R6/bin/xterm -fg $EGG
@@ -1294,7 +1294,7 @@ Illegal instruction
 ```console
 [...]
 ```
-```shell
+```console
 [aleph1]$ ./exploit4 2148 600
 Using address: 0xbffffb54
 [aleph1]$ /usr/X11R6/bin/xterm -fg $EGG
@@ -1443,7 +1443,7 @@ void main(int argc, char *argv[]) {
    Lets try our new exploit with our vulnerable test program:
 
 </PRE>
-```shell
+```console
 [aleph1]$ ./exploit4 768
 Using address: 0xbffffdb0
 [aleph1]$ ./vulnerable $RET
@@ -1454,7 +1454,7 @@ $
    Works like a charm. Now lets try it on xterm:
 
 </PRE>
-```shell
+```console
 [aleph1]$ export DISPLAY=:0.0
 [aleph1]$ ./exploit4 2148
 Using address: 0xbffffdb0

--- a/issues/72/11.md
+++ b/issues/72/11.md
@@ -1,5 +1,5 @@
 ---
-titel: Desync the Planet - Rsync RCE
+title: Desync the Planet - Rsync RCE
 author: Simon, Pedro, Jasiel
 ---
 |=----------------------------------------------------------------------=|

--- a/issues/72/11.txt
+++ b/issues/72/11.txt
@@ -1,5 +1,5 @@
 ---
-titel: Desync the Planet - Rsync RCE
+title: Desync the Planet - Rsync RCE
 author: Simon, Pedro, Jasiel
 ---
 |=----------------------------------------------------------------------=|

--- a/issues/72/12.md
+++ b/issues/72/12.md
@@ -1,5 +1,5 @@
 ---
-titel: Quantum ROP: ROP but cooler
+title: Quantum ROP: ROP but cooler
 author: Yoav Shifman, Yahav Rahom
 ---
 <PRE>

--- a/issues/72/12.txt
+++ b/issues/72/12.txt
@@ -1,5 +1,5 @@
 ---
-titel: Quantum ROP: ROP but cooler
+title: Quantum ROP: ROP but cooler
 author: Yoav Shifman, Yahav Rahom
 ---
 |=-----------------------------------------------------------------------=|

--- a/issues/72/14.md
+++ b/issues/72/14.md
@@ -1,5 +1,5 @@
 ---
-titel: Money for Nothing, Chips for Free
+title: Money for Nothing, Chips for Free
 author: Peter Honeyman
 ---
 |=-----------------------------------------------------------------------=|

--- a/issues/72/14.txt
+++ b/issues/72/14.txt
@@ -1,5 +1,5 @@
 ---
-titel: Money for Nothing, Chips for Free
+title: Money for Nothing, Chips for Free
 author: Peter Honeyman
 ---
 |=-----------------------------------------------------------------------=|


### PR DESCRIPTION
- `title` instead of `titel`
- the new website build started crashing hard on `/issues/49/14_md.html` with a Node/V8 fatal error. Using `console` instead of `shell` fixes it.